### PR TITLE
Fex file for the Sanei N90 tablet

### DIFF
--- a/sys_config/a10/sanei-n90.fex
+++ b/sys_config/a10/sanei-n90.fex
@@ -1,0 +1,896 @@
+[product]
+version = "1.0"
+machine = "A10-EVB-V1.1"
+
+[target]
+boot_clock = 1008
+dcdc2_vol = 1400
+dcdc3_vol = 1250
+ldo2_vol = 3000
+ldo3_vol = 2800
+ldo4_vol = 2800
+
+[card_burn_para]
+card_no = 0
+card_line = 4
+card_mode = 0
+sdc_d1 = port:PF00<2><1><default><default>
+sdc_d0 = port:PF01<2><1><default><default>
+sdc_clk = port:PF02<2><1><default><default>
+sdc_cmd = port:PF03<2><1><default><default>
+sdc_d3 = port:PF04<2><1><default><default>
+sdc_d2 = port:PF05<2><1><default><default>
+
+[card_boot]
+logical_start = 40960
+sprite_gpio0 =
+
+[card_boot0_para]
+card_ctrl = 0
+card_high_speed = 1
+card_line = 4
+sdc_d1 = port:PF00<2><1><default><default>
+sdc_d0 = port:PF01<2><1><default><default>
+sdc_clk = port:PF02<2><1><default><default>
+sdc_cmd = port:PF03<2><1><default><default>
+sdc_d3 = port:PF04<2><1><default><default>
+sdc_d2 = port:PF05<2><1><default><default>
+
+[card_boot2_para]
+card_ctrl = 2
+card_high_speed = 1
+card_line = 4
+sdc_cmd = port:PC06<3><1><default><default>
+sdc_clk = port:PC07<3><1><default><default>
+sdc_d0 = port:PC08<3><1><default><default>
+sdc_d1 = port:PC09<3><1><default><default>
+sdc_d2 = port:PC10<3><1><default><default>
+sdc_d3 = port:PC11<3><1><default><default>
+
+[twi_para]
+twi_port = 0
+twi_scl = port:PB00<2><default><default><default>
+twi_sda = port:PB01<2><default><default><default>
+
+[uart_para]
+uart_debug_port = 0
+uart_debug_tx = port:PB22<2><default><default><default>
+uart_debug_rx = port:PB23<2><default><default><default>
+
+[jtag_para]
+jtag_enable = 1
+jtag_ms = port:PF00<4><default><default><default>
+jtag_ck = port:PF01<4><default><default><default>
+jtag_do = port:PF03<4><default><default><default>
+jtag_di = port:PF05<4><default><default><default>
+
+[dram_para]
+dram_baseaddr = 0x40000000
+dram_clk = 456
+dram_type = 3
+dram_rank_num = 1
+dram_chip_density = 2048
+dram_io_width = 16
+dram_bus_width = 32
+dram_cas = 6
+dram_zq = 0x7b
+dram_odt_en = 0
+dram_size = 512
+dram_tpr0 = 0x30926692
+dram_tpr1 = 0x1090
+dram_tpr2 = 0x1a0c8
+dram_tpr3 = 0x0
+dram_tpr4 = 0x0
+dram_tpr5 = 0x0
+dram_emr1 = 0x4
+dram_emr2 = 0x0
+dram_emr3 = 0x0
+
+[mali_para]
+mali_used = 1
+mali_clkdiv = 3
+
+[g2d_para]
+g2d_used = 1
+g2d_size = 0x1000000
+
+[emac_para]
+emac_used = 0
+emac_rxd3 = port:PA00<2><default><default><default>
+emac_rxd2 = port:PA01<2><default><default><default>
+emac_rxd1 = port:PA02<2><default><default><default>
+emac_rxd0 = port:PA03<2><default><default><default>
+emac_txd3 = port:PA04<2><default><default><default>
+emac_txd2 = port:PA05<2><default><default><default>
+emac_txd1 = port:PA06<2><default><default><default>
+emac_txd0 = port:PA07<2><default><default><default>
+emac_rxclk = port:PA08<2><default><default><default>
+emac_rxerr = port:PA09<2><default><default><default>
+emac_rxdV = port:PA10<2><default><default><default>
+emac_mdc = port:PA11<2><default><default><default>
+emac_mdio = port:PA12<2><default><default><default>
+emac_txen = port:PA13<2><default><default><default>
+emac_txclk = port:PA14<2><default><default><default>
+emac_crs = port:PA15<2><default><default><default>
+emac_col = port:PA16<2><default><default><default>
+emac_reset = port:PA17<1><default><default><default>
+
+[twi0_para]
+twi0_used = 1
+twi0_scl = port:PB00<2><default><default><default>
+twi0_sda = port:PB01<2><default><default><default>
+
+[twi1_para]
+twi1_used = 1
+twi1_scl = port:PB18<2><default><default><default>
+twi1_sda = port:PB19<2><default><default><default>
+
+[twi2_para]
+twi2_used = 1
+twi2_scl = port:PB20<2><default><default><default>
+twi2_sda = port:PB21<2><default><default><default>
+
+[uart_para0]
+uart_used = 1
+uart_port = 0
+uart_type = 2
+uart_tx = port:PB22<2><default><default><default>
+uart_rx = port:PB23<2><default><default><default>
+
+[uart_para1]
+uart_used = 0
+uart_port = 1
+uart_type = 8
+uart_tx = port:PA10<4><default><default><default>
+uart_rx = port:PA11<4><default><default><default>
+uart_rts = port:PA12<4><default><default><default>
+uart_cts = port:PA13<4><default><default><default>
+uart_dtr = port:PA14<4><default><default><default>
+uart_dsr = port:PA15<4><default><default><default>
+uart_dcd = port:PA16<4><default><default><default>
+uart_ring = port:PA17<4><default><default><default>
+
+[uart_para2]
+uart_used = 1
+uart_port = 2
+uart_type = 4
+uart_tx = port:PI18<3><default><default><default>
+uart_rx = port:PI19<3><1><default><default>
+uart_rts = port:PI16<3><default><default><default>
+uart_cts = port:PI17<3><default><default><default>
+
+[uart_para3]
+uart_used = 0
+uart_port = 3
+uart_type = 4
+uart_tx = port:PH00<4><default><default><default>
+uart_rx = port:PH01<4><default><default><default>
+uart_rts = port:PH02<4><default><default><default>
+uart_cts = port:PH03<4><default><default><default>
+
+[uart_para4]
+uart_used = 0
+uart_port = 4
+uart_type = 2
+uart_tx = port:PH04<4><default><default><default>
+uart_rx = port:PH05<4><default><default><default>
+
+[uart_para5]
+uart_used = 0
+uart_port = 5
+uart_type = 2
+uart_tx = port:PH06<4><default><default><default>
+uart_rx = port:PH07<4><default><default><default>
+
+[uart_para6]
+uart_used = 0
+uart_port = 6
+uart_type = 2
+uart_tx = port:PA12<4><default><default><default>
+uart_rx = port:PA13<4><default><default><default>
+
+[uart_para7]
+uart_used = 0
+uart_port = 7
+uart_type = 2
+uart_tx = port:PA14<4><default><default><default>
+uart_rx = port:PA15<4><default><default><default>
+
+[spi0_para]
+spi_used = 0
+spi_cs0 = port:PI10<3><default><default><default>
+spi_cs1 = port:PI14<3><default><default><default>
+spi_sclk = port:PI11<3><default><default><default>
+spi_mosi = port:PI12<3><default><default><default>
+spi_miso = port:PI13<3><default><default><default>
+
+[spi1_para]
+spi_used = 0
+spi_cs0 = port:PA00<4><default><default><default>
+spi_cs1 = port:PA04<4><default><default><default>
+spi_sclk = port:PI01<4><default><default><default>
+spi_mosi = port:PI02<4><default><default><default>
+spi_miso = port:PI03<4><default><default><default>
+
+[spi2_para]
+spi_used = 0
+spi_cs0 = port:PC19<3><default><default><default>
+spi_cs1 =
+spi_sclk = port:PC20<3><default><default><default>
+spi_mosi = port:PC21<3><default><default><default>
+spi_miso = port:PC22<3><default><default><default>
+
+[spi3_para]
+spi_used = 0
+spi_cs0 = port:PA05<4><default><default><default>
+spi_cs1 = port:PA09<4><default><default><default>
+spi_sclk = port:PI06<4><default><default><default>
+spi_mosi = port:PI07<4><default><default><default>
+spi_miso = port:PI08<4><default><default><default>
+
+[rtp_para]
+rtp_used = 0
+rtp_screen_size = 7
+rtp_regidity_level = 5
+rtp_press_threshold_enable = 0
+rtp_press_threshold = 0x1f40
+rtp_sensitive_level = 0xf
+rtp_exchange_x_y_flag = 0
+
+[ctp_para]
+ctp_used = 1
+ctp_name = "ft5x_ts"
+ctp_twi_id = 2
+ctp_twi_addr = 0x38
+ctp_screen_max_x = 1024
+ctp_screen_max_y = 768
+ctp_revert_x_flag = 0
+ctp_revert_y_flag = 0
+ctp_exchange_x_y_flag = 0
+ctp_int_port = port:PH21<6><default><default><default>
+ctp_wakeup = port:PB13<1><default><default><1>
+ctp_io_port = port:PH21<0><default><default><default>
+
+[tkey_para]
+tkey_used = 0
+tkey_name = "hv_keypad"
+tkey_twi_id = 2
+tkey_twi_addr = 0x62
+tkey_int = port:PI13<6><default><default><default>
+
+[motor_para]
+motor_used = 1
+motor_shake = port:PB03<1><default><default><0>
+
+[nand_para]
+nand_used = 1
+nand_we = port:PC00<2><default><default><default>
+nand_ale = port:PC01<2><default><default><default>
+nand_cle = port:PC02<2><default><default><default>
+nand_ce1 = port:PC03<2><default><default><default>
+nand_ce0 = port:PC04<2><default><default><default>
+nand_nre = port:PC05<2><default><default><default>
+nand_rb0 = port:PC06<2><default><default><default>
+nand_rb1 = port:PC07<2><default><default><default>
+nand_d0 = port:PC08<2><default><default><default>
+nand_d1 = port:PC09<2><default><default><default>
+nand_d2 = port:PC10<2><default><default><default>
+nand_d3 = port:PC11<2><default><default><default>
+nand_d4 = port:PC12<2><default><default><default>
+nand_d5 = port:PC13<2><default><default><default>
+nand_d6 = port:PC14<2><default><default><default>
+nand_d7 = port:PC15<2><default><default><default>
+nand_wp = port:PC16<2><default><default><default>
+nand_ce2 = port:PC17<2><default><default><default>
+nand_ce3 = port:PC18<2><default><default><default>
+nand_ce4 =
+nand_ce5 =
+nand_ce6 =
+nand_ce7 =
+nand_spi = port:PC23<3><default><default><default>
+nand_ndqs = port:PC24<2><default><default><default>
+
+[disp_init]
+disp_init_enable = 1
+disp_mode = 0
+screen0_output_type = 1
+screen0_output_mode = 4
+screen1_output_type = 1
+screen1_output_mode = 4
+fb0_framebuffer_num = 2
+fb0_format = 10
+fb0_pixel_sequence = 0
+fb0_scaler_mode_enable = 0
+fb1_framebuffer_num = 2
+fb1_format = 10
+fb1_pixel_sequence = 0
+fb1_scaler_mode_enable = 0
+
+[lcd0_para]
+lcd_used = 1
+lcd_x = 1024
+lcd_y = 768
+lcd_dclk_freq = 100
+lcd_pwm_freq = 10000
+lcd_pwm_pol = 1
+lcd_if = 3
+lcd_srgb = 2105376
+lcd_hbp = 800
+lcd_ht = 2084
+lcd_vbp = 16
+lcd_vt = 1600
+lcd_hv_if = 0
+lcd_hv_smode = 0
+lcd_hv_s888_if = 0
+lcd_hv_syuv_if = 0
+lcd_hv_vspw = 10
+lcd_hv_hspw = 320
+lcd_hv_lde_used = 0
+lcd_hv_lde_iovalue = 0
+lcd_ttl_stvh = 0
+lcd_ttl_stvdl = 0
+lcd_ttl_stvdp = 0
+lcd_ttl_ckvt = 0
+lcd_ttl_ckvh = 0
+lcd_ttl_ckvd = 0
+lcd_ttl_oevt = 0
+lcd_ttl_oevh = 0
+lcd_ttl_oevd = 0
+lcd_ttl_sthh = 0
+lcd_ttl_sthd = 0
+lcd_ttl_oehh = 0
+lcd_ttl_oehd = 0
+lcd_ttl_revd = 0
+lcd_ttl_datarate = 0
+lcd_ttl_revsel = 0
+lcd_ttl_datainv_en = 0
+lcd_ttl_datainv_sel = 0
+lcd_lvds_ch = 0
+lcd_lvds_mode = 0
+lcd_lvds_bitwidth = 1
+lcd_lvds_io_cross = 0
+lcd_cpu_if = 0
+lcd_cpu_da = 0
+lcd_frm = 1
+lcd_io_cfg0 = 0
+lcd_io_cfg1 = 0
+lcd_io_strength = 0
+lcd_bl_en_used = 1
+lcd_bl_en = port:PH07<1><default><default><1>
+lcd_power_used = 1
+lcd_power = port:PH08<1><default><default><1>
+lcd_pwm_used = 1
+lcd_pwm = port:PB02<2><default><default><default>
+lcd_gpio_0 =
+lcd_gpio_1 =
+lcd_gpio_2 =
+lcd_gpio_3 =
+lcdd0 = port:PD00<2><default><default><default>
+lcdd1 = port:PD01<2><default><default><default>
+lcdd2 = port:PD02<2><default><default><default>
+lcdd3 = port:PD03<2><default><default><default>
+lcdd4 = port:PD04<2><default><default><default>
+lcdd5 = port:PD05<2><default><default><default>
+lcdd6 = port:PD06<2><default><default><default>
+lcdd7 = port:PD07<2><default><default><default>
+lcdd8 = port:PD08<2><default><default><default>
+lcdd9 = port:PD09<2><default><default><default>
+lcdd10 = port:PD10<2><default><default><default>
+lcdd11 = port:PD11<2><default><default><default>
+lcdd12 = port:PD12<2><default><default><default>
+lcdd13 = port:PD13<2><default><default><default>
+lcdd14 = port:PD14<2><default><default><default>
+lcdd15 = port:PD15<2><default><default><default>
+lcdd16 = port:PD16<2><default><default><default>
+lcdd17 = port:PD17<2><default><default><default>
+lcdd18 = port:PD18<2><default><default><default>
+lcdd19 = port:PD19<2><default><default><default>
+lcdd20 = port:PD20<2><default><default><default>
+lcdd21 = port:PD21<2><default><default><default>
+lcdd22 = port:PD22<2><default><default><default>
+lcdd23 = port:PD23<2><default><default><default>
+lcdclk = port:PD24<2><default><default><default>
+lcdde = port:PD25<2><default><default><default>
+lcdhsync = port:PD26<2><default><default><default>
+lcdvsync = port:PD27<2><default><default><default>
+
+[lcd1_para]
+lcd_used = 0
+lcd_x = 0
+lcd_y = 0
+lcd_dclk_freq = 0
+lcd_pwm_freq = 0
+lcd_pwm_pol = 0
+lcd_srgb = 0
+lcd_swap = 0
+lcd_if = 0
+lcd_hbp = 0
+lcd_ht = 0
+lcd_vbp = 0
+lcd_vt = 0
+lcd_hv_if = 0
+lcd_hv_smode = 0
+lcd_hv_s888_if = 0
+lcd_hv_syuv_if = 0
+lcd_hv_vspw = 0
+lcd_hv_hspw = 0
+lcd_hv_lde_used = 0
+lcd_hv_lde_iovalue = 0
+lcd_ttl_stvh = 0
+lcd_ttl_stvdl = 0
+lcd_ttl_stvdp = 0
+lcd_ttl_ckvt = 0
+lcd_ttl_ckvh = 0
+lcd_ttl_ckvd = 0
+lcd_ttl_oevt = 0
+lcd_ttl_oevh = 0
+lcd_ttl_oevd = 0
+lcd_ttl_sthh = 0
+lcd_ttl_sthd = 0
+lcd_ttl_oehh = 0
+lcd_ttl_oehd = 0
+lcd_ttl_revd = 0
+lcd_ttl_datarate = 0
+lcd_ttl_revsel = 0
+lcd_ttl_datainv_en = 0
+lcd_ttl_datainv_sel = 0
+lcd_lvds_ch = 0
+lcd_lvds_mode = 0
+lcd_lvds_bitwidth = 0
+lcd_lvds_io_cross = 0
+lcd_cpu_if = 0
+lcd_cpu_da = 0
+lcd_frm = 0
+lcd_io_cfg0 = 0
+lcd_io_cfg1 = 0
+lcd_io_strength = 0
+lcd_bl_en_used = 0
+lcd_bl_en =
+lcd_power_used = 0
+lcd_power =
+lcd_pwm_used = 1
+lcd_pwm = port:PI03<2><default><default><default>
+lcd_gpio_0 =
+lcd_gpio_1 =
+lcd_gpio_2 =
+lcd_gpio_3 =
+lcdd0 = port:PH00<2><default><default><default>
+lcdd1 = port:PH01<2><default><default><default>
+lcdd2 = port:PH02<2><default><default><default>
+lcdd3 = port:PH03<2><default><default><default>
+lcdd4 = port:PH04<2><default><default><default>
+lcdd5 = port:PH05<2><default><default><default>
+lcdd6 = port:PH06<2><default><default><default>
+lcdd7 = port:PH07<2><default><default><default>
+lcdd8 = port:PH08<2><default><default><default>
+lcdd9 = port:PH09<2><default><default><default>
+lcdd10 = port:PH10<2><default><default><default>
+lcdd11 = port:PH11<2><default><default><default>
+lcdd12 = port:PH12<2><default><default><default>
+lcdd13 = port:PH13<2><default><default><default>
+lcdd14 = port:PH14<2><default><default><default>
+lcdd15 = port:PH15<2><default><default><default>
+lcdd16 = port:PH16<2><default><default><default>
+lcdd17 = port:PH17<2><default><default><default>
+lcdd18 = port:PH18<2><default><default><default>
+lcdd19 = port:PH19<2><default><default><default>
+lcdd20 = port:PH20<2><default><default><default>
+lcdd21 = port:PH21<2><default><default><default>
+lcdd22 = port:PH22<2><default><default><default>
+lcdd23 = port:PH23<2><default><default><default>
+lcdclk = port:PH24<2><default><default><default>
+lcdde = port:PH25<2><default><default><default>
+lcdhsync = port:PH26<2><default><default><default>
+lcdvsync = port:PH27<2><default><default><default>
+
+[csi0_para]
+csi_used = 1
+csi_mode = 0
+csi_dev_qty = 2
+csi_stby_mode = 1
+csi_mname = "gc0308"
+csi_twi_id = 1
+csi_twi_addr = 0x42
+csi_if = 0
+csi_vflip = 0
+csi_hflip = 0
+csi_iovdd = "axp20_pll"
+csi_avdd = "axp20_pll"
+csi_dvdd = ""
+csi_flash_pol = 1
+csi_mname_b = "gc0308b"
+csi_twi_id_b = 1
+csi_twi_addr_b = 0x46
+csi_if_b = 0
+csi_vflip_b = 0
+csi_hflip_b = 0
+csi_iovdd_b = "axp20_pll"
+csi_avdd_b = "axp20_pll"
+csi_dvdd_b = ""
+csi_flash_pol_b = 1
+csi_pck = port:PE00<3><default><default><default>
+csi_ck = port:PE01<3><default><default><default>
+csi_hsync = port:PE02<3><default><default><default>
+csi_vsync = port:PE03<3><default><default><default>
+csi_d0 = port:PE04<3><default><default><default>
+csi_d1 = port:PE05<3><default><default><default>
+csi_d2 = port:PE06<3><default><default><default>
+csi_d3 = port:PE07<3><default><default><default>
+csi_d4 = port:PE08<3><default><default><default>
+csi_d5 = port:PE09<3><default><default><default>
+csi_d6 = port:PE10<3><default><default><default>
+csi_d7 = port:PE11<3><default><default><default>
+csi_d8 =
+csi_d9 =
+csi_d10 =
+csi_d11 =
+csi_d12 =
+csi_d13 =
+csi_d14 =
+csi_d15 =
+csi_reset = port:PH13<1><default><default><0>
+csi_power_en = port:PH16<1><default><default><0>
+csi_stby = port:PH18<1><default><default><1>
+csi_reset_b = port:PH14<1><default><default><0>
+csi_power_en_b = port:PH16<1><default><default><0>
+csi_stby_b = port:PH19<1><default><default><1>
+
+[csi1_para]
+csi_used = 0
+csi_mname = "gc0308"
+csi_twi_id = 1
+csi_twi_addr = 0x42
+csi_if = 0
+csi_mode = 0
+csi_dev_qty = 1
+csi_vflip = 0
+csi_hflip = 0
+csi_stby_mode = 1
+csi_iovdd = "axp20_hdmi"
+csi_avdd = "axp20_hdmi"
+csi_dvdd = ""
+csi_pck = port:PG00<3><default><default><default>
+csi_ck = port:PG01<3><default><default><default>
+csi_hsync = port:PG02<3><default><default><default>
+csi_vsync = port:PG03<3><default><default><default>
+csi_d0 = port:PG04<3><default><default><default>
+csi_d1 = port:PG05<3><default><default><default>
+csi_d2 = port:PG06<3><default><default><default>
+csi_d3 = port:PG07<3><default><default><default>
+csi_d4 = port:PG08<3><default><default><default>
+csi_d5 = port:PG09<3><default><default><default>
+csi_d6 = port:PG10<3><default><default><default>
+csi_d7 = port:PG11<3><default><default><default>
+csi_d8 =
+csi_d9 =
+csi_d10 =
+csi_d11 =
+csi_d12 =
+csi_d13 =
+csi_d14 =
+csi_d15 =
+csi_d16 =
+csi_d17 =
+csi_d18 =
+csi_d19 =
+csi_d20 =
+csi_d21 =
+csi_d22 =
+csi_d23 =
+csi_reset = port:PH14<1><default><default><0>
+csi_power_en = port:PH17<1><default><default><0>
+csi_stby = port:PH19<1><default><default><1>
+csi_reset_b =
+csi_power_en_b =
+csi_stby_b =
+
+[tvout_para]
+tvout_used = 0
+tvout_channel_num = 1
+tv_en = port:PI12<1><default><default><0>
+
+[tvin_para]
+tvin_used = 0
+tvin_channel_num = 4
+
+[sata_para]
+sata_used = 0
+sata_power_en =
+
+[mmc0_para]
+sdc_used = 1
+sdc_detmode = 1
+bus_width = 4
+sdc_d1 = port:PF00<2><1><2><default>
+sdc_d0 = port:PF01<2><1><2><default>
+sdc_clk = port:PF02<2><1><2><default>
+sdc_cmd = port:PF03<2><1><2><default>
+sdc_d3 = port:PF04<2><1><2><default>
+sdc_d2 = port:PF05<2><1><2><default>
+sdc_det = port:PH01<0><1><default><default>
+sdc_use_wp = 0
+sdc_wp =
+
+[mmc1_para]
+sdc_used = 0
+sdc_detmode = 1
+bus_width = 4
+sdc_cmd = port:PH22<5><1><2><default>
+sdc_clk = port:PH23<5><1><2><default>
+sdc_d0 = port:PH24<5><1><2><default>
+sdc_d1 = port:PH25<5><1><2><default>
+sdc_d2 = port:PH26<5><1><2><default>
+sdc_d3 = port:PH27<5><1><2><default>
+sdc_det = port:PH02<0><1><default><default>
+sdc_use_wp = 0
+sdc_wp =
+
+[mmc2_para]
+sdc_used = 0
+
+[mmc3_para]
+sdc_used = 1
+sdc_detmode = 4
+bus_width = 4
+sdc_cmd = port:PI04<2><1><2><default>
+sdc_clk = port:PI05<2><1><2><default>
+sdc_d0 = port:PI06<2><1><2><default>
+sdc_d1 = port:PI07<2><1><2><default>
+sdc_d2 = port:PI08<2><1><2><default>
+sdc_d3 = port:PI09<2><1><2><default>
+sdc_det =
+sdc_use_wp = 0
+sdc_wp =
+
+[ms_para]
+ms_used = 0
+ms_bs = port:PH06<5><default><default><default>
+ms_clk = port:PH07<5><default><default><default>
+ms_d0 = port:PH08<5><default><default><default>
+ms_d1 = port:PH09<5><default><default><default>
+ms_d2 = port:PH10<5><default><default><default>
+ms_d3 = port:PH11<5><default><default><default>
+ms_det =
+
+[smc_para]
+smc_used = 0
+smc_rst = port:PH13<5><default><default><default>
+smc_vppen = port:PH14<5><default><default><default>
+smc_vppp = port:PH15<5><default><default><default>
+smc_det = port:PH16<5><default><default><default>
+smc_vccen = port:PH17<5><default><default><default>
+smc_sck = port:PH18<5><default><default><default>
+smc_sda = port:PH19<5><default><default><default>
+
+[ps2_0_para]
+ps2_used = 0
+ps2_scl = port:PI20<2><1><default><default>
+ps2_sda = port:PI21<2><1><default><default>
+
+[ps2_1_para]
+ps2_used = 0
+ps2_scl = port:PI14<3><1><default><default>
+ps2_sda = port:PI15<3><1><default><default>
+
+[can_para]
+can_used = 0
+can_tx = port:PA16<3><default><default><default>
+can_rx = port:PA17<3><default><default><default>
+
+[keypad_para]
+kp_used = 0
+kp_in_size = 8
+kp_out_size = 8
+kp_in0 = port:PH08<4><1><default><default>
+kp_in1 = port:PH09<4><1><default><default>
+kp_in2 = port:PH10<4><1><default><default>
+kp_in3 = port:PH11<4><1><default><default>
+kp_in4 = port:PH14<4><1><default><default>
+kp_in5 = port:PH15<4><1><default><default>
+kp_in6 = port:PH16<4><1><default><default>
+kp_in7 = port:PH17<4><1><default><default>
+kp_out0 = port:PH18<4><1><default><default>
+kp_out1 = port:PH19<4><1><default><default>
+kp_out2 = port:PH22<4><1><default><default>
+kp_out3 = port:PH23<4><1><default><default>
+kp_out4 = port:PH24<4><1><default><default>
+kp_out5 = port:PH25<4><1><default><default>
+kp_out6 = port:PH26<4><1><default><default>
+kp_out7 = port:PH27<4><1><default><default>
+
+[usbc0]
+usb_used = 1
+usb_port_type = 2
+usb_detect_type = 1
+usb_id_gpio = port:PH04<0><1><default><default>
+usb_det_vbus_gpio = port:PH05<0><0><default><default>
+usb_drv_vbus_gpio = port:PB09<1><0><default><0>
+usb_host_init_state = 0
+
+[usbc1]
+usb_used = 1
+usb_port_type = 1
+usb_detect_type = 0
+usb_id_gpio =
+usb_det_vbus_gpio =
+usb_drv_vbus_gpio = port:PH06<1><0><default><0>
+usb_host_init_state = 1
+
+[usbc2]
+usb_used = 1
+usb_port_type = 1
+usb_detect_type = 0
+usb_id_gpio =
+usb_det_vbus_gpio =
+usb_drv_vbus_gpio = port:PH12<1><0><default><1>
+usb_host_init_state = 0
+
+[usb_feature]
+vendor_id = 6353
+mass_storage_id = 1
+adb_id = 2
+manufacturer_name = "USB Developer"
+product_name = "Android"
+serial_number = "20080411"
+
+[msc_feature]
+vendor_name = "ANDROID"
+product_name = "USB 2.0"
+release = 100
+luns = 2
+
+[gsensor_para]
+gsensor_used = 1
+gsensor_name = "bma250"
+gsensor_twi_id = 1
+gsensor_twi_addr = 0x18
+gsensor_int1 = port:PH00<6><1><default><default>
+gsensor_int2 = port:PI10<6><1><default><default>
+
+[gps_para]
+gps_used = 0
+gps_spi_id = 2
+gps_spi_cs_num = 0
+gps_lradc = 1
+gps_clk = port:PI00<2><default><default><default>
+gps_sign = port:PI01<2><default><default><default>
+gps_mag = port:PI02<2><default><default><default>
+gps_vcc_en = port:PC22<1><default><default><0>
+gps_osc_en = port:PI14<1><default><default><0>
+gps_rx_en = port:PI15<1><default><default><0>
+
+[sdio_wifi_para]
+sdio_wifi_used = 0
+sdio_wifi_sdc_id = 3
+sdio_wifi_mod_sel = 1
+swl_n20_shdn = port:PH09<1><default><default><0>
+swl_n20_host_wakeup = port:PH10<1><default><default><1>
+swl_n20_vdd_en = port:PH11<1><default><default><0>
+swl_n20_vcc_en = port:PH12<1><default><default><0>
+
+[usb_wifi_para]
+usb_wifi_used = 1
+usb_wifi_usbc_num = 2
+
+[3g_para]
+3g_used = 0
+3g_usbc_num = 2
+3g_uart_num = 0
+3g_pwr =
+3g_wakeup =
+3g_int =
+
+[gy_para]
+gy_used = 0
+gy_twi_id = 1
+gy_twi_addr = 0
+gy_int1 = port:PH18<6><1><default><default>
+gy_int2 = port:PH19<6><1><default><default>
+
+[ls_para]
+ls_used = 0
+ls_twi_id = 1
+ls_twi_addr = 0
+ls_int = port:PH20<6><1><default><default>
+
+[compass_para]
+compass_used = 0
+compass_twi_id = 1
+compass_twi_addr = 0
+compass_int = port:PI13<6><1><default><default>
+
+[bt_para]
+bt_used = 1
+bt_uart_id = 2
+bt_wakeup = port:PI20<1><default><default><1>
+bt_gpio = port:PI21<1><default><default><1>
+bt_rst = port:PB05<1><default><default><0>
+
+[i2s_para]
+i2s_used = 0
+i2s_channel = 2
+i2s_mclk = port:PB05<2><1><default><default>
+i2s_bclk = port:PB06<2><1><default><default>
+i2s_lrclk = port:PB07<2><1><default><default>
+i2s_dout0 = port:PB08<2><1><default><default>
+i2s_dout1 =
+i2s_dout2 =
+i2s_dout3 =
+i2s_din = port:PB12<2><1><default><default>
+
+[spdif_para]
+spdif_used = 0
+spdif_mclk =
+spdif_dout = port:PB13<4><1><default><default>
+spdif_din =
+
+[audio_para]
+audio_used = 1
+audio_pa_ctrl = port:PH15<1><default><default><0>
+
+[ir_para]
+ir_used = 0
+ir0_rx = port:PB04<2><default><default><default>
+
+[pmu_para]
+pmu_used = 1
+pmu_twi_addr = 52
+pmu_twi_id = 0
+pmu_irq_id = 0
+pmu_battery_rdc = 200
+pmu_battery_cap = 7000
+pmu_init_chgcur = 300
+pmu_earlysuspend_chgcur = 600
+pmu_suspend_chgcur = 1000
+pmu_resume_chgcur = 300
+pmu_shutdown_chgcur = 1000
+pmu_init_chgvol = 4200
+pmu_init_chgend_rate = 15
+pmu_init_chg_enabled = 1
+pmu_init_adc_freq = 100
+pmu_init_adc_freqc = 100
+pmu_init_chg_pretime = 50
+pmu_init_chg_csttime = 720
+pmu_bat_para1 = 0
+pmu_bat_para2 = 0
+pmu_bat_para3 = 1
+pmu_bat_para4 = 5
+pmu_bat_para5 = 6
+pmu_bat_para6 = 7
+pmu_bat_para7 = 8
+pmu_bat_para8 = 14
+pmu_bat_para9 = 20
+pmu_bat_para10 = 40
+pmu_bat_para11 = 50
+pmu_bat_para12 = 58
+pmu_bat_para13 = 73
+pmu_bat_para14 = 83
+pmu_bat_para15 = 90
+pmu_bat_para16 = 100
+pmu_usbvol = 4000
+pmu_usbcur = 500
+pmu_usbvol_pc = 4000
+pmu_usbcur_pc = 500
+pmu_pwroff_vol = 3300
+pmu_pwron_vol = 2900
+pmu_pekoff_time = 6000
+pmu_pekoff_en = 1
+pmu_peklong_time = 1500
+pmu_pekon_time = 1000
+pmu_pwrok_time = 64
+pmu_pwrnoe_time = 2000
+pmu_intotp_en = 1
+pmu_used2 = 0
+pmu_adpdet = port:PH02<0><default><default><default>
+pmu_init_chgcur2 = 400
+pmu_earlysuspend_chgcur2 = 600
+pmu_suspend_chgcur2 = 1200
+pmu_resume_chgcur2 = 400
+pmu_shutdown_chgcur2 = 1200
+pmu_batdeten = 1
+pmu_suspendpwroff_vol = 3500
+
+[recovery_key]
+key_min = 16
+key_max = 20
+


### PR DESCRIPTION
Model SANEI N90
 CPU All-winner A10 1GHz (firmware) overclocks to 1.5GHz GPU: Mali-400 MP
 RAM 1GB (DDR 3)
 ROM（Memory） 16GB Nand Flash
 Shell Material Plastic
 Screen Size 9.7 Inch
 Type Capacitive Screen, IPS
 Display LED
 Resolution 1024 x 768px
 Visible Angle 150°

 Extend Card Support TF card up to 32GB extended
 Camera Dual camera, front is 0.3 and rear is 2.0 Megapixel
 Gravity Sensor Yes
 Multi-Touch Yes, 10 points touch
 Flash Support Flash 11.1
 Android Market Yes, support google play/android market
 Bluetooth No

 USB HOST 2.0
 WIFI Yes, 802.11 b/g/n
 3G Not built in, supports external 3G USB dongles: E1916, ZTE AC2736, HUAWEI E1750, HUAWEI EC122, HUAWEI EM770W
 Earphone Interface 3.5mm
 Work Time Up to 8~10 hours
 Battery 7000 MAh
