### PR TITLE
Fix u-host Wi-Fi and OTG USB parameters

### DIFF
--- a/sys_config/a10/uhost_u1a.fex
+++ b/sys_config/a10/uhost_u1a.fex
@@ -729,12 +729,12 @@ kp_out7 = port:PH27<4><1><default><default>
 
 [usbc0]
 usb_used = 1
-usb_port_type = 0
-usb_detect_type = 0
-usb_id_gpio =
-usb_det_vbus_gpio =
+usb_port_type = 2
+usb_detect_type = 1
+usb_id_gpio = port:PH04<0><1><default><default>
+usb_det_vbus_gpio = port:PH05<0><0><default><default>
 usb_drv_vbus_gpio = port:PB09<1><0><default><0>
-usb_host_init_state = 0
+usb_host_init_state = 1
 
 [usbc1]
 usb_used = 1
@@ -751,7 +751,7 @@ usb_port_type = 1
 usb_detect_type = 0
 usb_id_gpio =
 usb_det_vbus_gpio =
-usb_drv_vbus_gpio = port:PH03<1><0><default><0>
+usb_drv_vbus_gpio = port:PH12<1><0><default><0>
 usb_host_init_state = 1
 
 [usb_feature]


### PR DESCRIPTION
I tested the current fex for the u-host and found that it wasn't picking up the OTG port in host mode or finding the usb Wi-Fi chipset. Pulled up my old shared work from mk802ii and the u-host/OE and dumps of the uhost roms and added back the working code. Might push some more changes later as well if they prove useful in any way.
