### PR TITLE
Fixed UART 6 & 7 para

### DIFF
--- a/sys_config/a20/a20-olinuxino_micro.fex
+++ b/sys_config/a20/a20-olinuxino_micro.fex
@@ -191,15 +191,15 @@ uart_rx = port:PH07<4><1><default><default>
 uart_used = 1
 uart_port = 6
 uart_type = 2
-uart_tx = port:PI12<4><1><default><default>
-uart_rx = port:PI13<4><1><default><default>
+uart_tx = port:PI12<3><1><default><default>
+uart_rx = port:PI13<3><1><default><default>
 
 [uart_para7]
 uart_used = 1
 uart_port = 7
 uart_type = 2
-uart_tx = port:PI20<4><1><default><default>
-uart_rx = port:PI21<4><1><default><default>
+uart_tx = port:PI20<3><1><default><default>
+uart_rx = port:PI21<3><1><default><default>
 
 [spi0_para]
 spi_used = 0


### PR DESCRIPTION
There was a bug due to which UART 6 & 7 were not working. 
Uart 6 and 7 is on mux 3, according to a20 pio table, while in the FEX it was mentioned as 4.
