### PR TITLE
Add automated .fex testing via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# use container-based infrastructure
+sudo: false
+
+os: linux
+
+# retrieve and extract sunxi-tools archive, run dedicated test rule
+script:
+  - wget -O sunxi-tools.zip https://github.com/linux-sunxi/sunxi-tools/archive/master.zip
+  - unzip -q sunxi-tools.zip
+  - make -C sunxi-tools-master/tests/ sunxi-boards_CI BOARDS_DIR=../..
+
+# turn off email notifications
+notifications:
+  - email: false


### PR DESCRIPTION
This commit creates a build configuration for https://travis-ci.org,
to download and run the .fex tests that sunxi-tools uses for the
FEX compiler.

GitHub will run these tests automatically on new commits and merge
requests, so they could serve as an "early warning" system that
notifies about contributions that are either faulty, or cannot by
handled properly by our sunxi-fexc utility.

For an example, see https://travis-ci.org/n1tehawk/sunxi-boards/builds/175993121

Note:
1. To actually enable testing, someone with admin access needs to enable the sunxi-boards repository at Travis.
2. The testing currently would FAIL, as long as #51 isn't addressed. To work around that, sunxi-tools automatically applies a suitable patch.

Regards, NiteHawk